### PR TITLE
Remove boost from apache-arrow libs

### DIFF
--- a/apache-arrow
+++ b/apache-arrow
@@ -22,7 +22,7 @@ $BREW install --force-bottle $BREW_DEPS $PKG_BREW_NAME 2>&1 | perl -pe 's/Warnin
 
 # Hardcode this for my custom autobrew build
 rm -f $BREWDIR/lib/*.dylib
-PKG_LIBS="-L$BREWDIR/lib -lparquet -larrow_dataset -larrow -lthrift -llz4 -lboost_system -lboost_filesystem -lboost_regex -lsnappy"
+PKG_LIBS="-L$BREWDIR/lib -larrow_dataset -lparquet -larrow -lthrift -llz4 -lsnappy"
 
 # Prevent CRAN builder from linking against old libs in /usr/local/lib
 for FILE in $BREWDIR/Cellar/*/*/lib/*.a; do


### PR DESCRIPTION
FWIW I can't confirm that arrow 0.17 builds with the bottle you built for it until you merge https://github.com/autobrew/homebrew-core/pull/3. See https://artifacts.r-hub.io/arrow_0.17.0.tar.gz-d3c9300ab1684feba2d30b534988d21c/arrow.Rcheck/00install.out

Not a big deal, of course.