### PR TITLE
Prep for Arrow 4.0.0

### DIFF
--- a/apache-arrow
+++ b/apache-arrow
@@ -1,6 +1,6 @@
-# We have bundles for 2.0.0 and 3.0.0 now
-if [ "$VERSION" != "2.0.0" ]; then
-VERSION="3.0.0"
+# We have bundles for 2.0.0 and 3.0.0 and 4.0.0 now
+if [ "$VERSION" != "2.0.0" ] && [ "$VERSION" != "3.0.0" ]; then
+VERSION="4.0.0"
 fi
 
 # Find a bundle

--- a/apache-arrow
+++ b/apache-arrow
@@ -29,7 +29,11 @@ rm -f libs.tar.xz
 
 # Hardcoded flags
 AWS_LIBS="-laws-cpp-sdk-config -laws-cpp-sdk-transfer -laws-cpp-sdk-identity-management -laws-cpp-sdk-cognito-identity -laws-cpp-sdk-sts -laws-cpp-sdk-s3 -laws-cpp-sdk-core -laws-c-event-stream -laws-checksums -laws-c-common -lpthread -lcurl"
-PKG_LIBS="-L$BREWDIR/lib -lparquet -larrow_dataset -larrow -larrow_bundled_dependencies -lthrift -llz4 -lsnappy -lzstd $AWS_LIBS"
+PKG_LIBS="-lparquet -larrow_dataset -larrow -larrow_bundled_dependencies -lthrift -llz4 -lsnappy -lzstd $AWS_LIBS"
+PKG_DIRS="-L$BREWDIR/lib"
+if [ "$VERSION" = "3.0.0" ] || [ "$VERSION" = "2.0.0" ]; then
+  PKG_LIBS="$PKG_DIRS $PKG_LIBS"
+fi
 PKG_CFLAGS="-I$BREWDIR/include -DARROW_R_WITH_S3"
 
 # Cleanup


### PR DESCRIPTION
In Arrow 4.0.0 (releasing soon) we made a change to separate the `-l` and `-L` flags, putting the former in `PKG_LIBS` and the latter in `PKG_DIRS` (https://issues.apache.org/jira/browse/ARROW-11735). This PR updates the boostrapping script accordingly.