### PR TITLE
Add missing cflags for apache-arrow 4.0.0

### DIFF
--- a/apache-arrow
+++ b/apache-arrow
@@ -33,8 +33,10 @@ PKG_LIBS="-lparquet -larrow_dataset -larrow -larrow_bundled_dependencies -lthrif
 PKG_DIRS="-L$BREWDIR/lib"
 if [ "$VERSION" = "3.0.0" ] || [ "$VERSION" = "2.0.0" ]; then
   PKG_LIBS="$PKG_DIRS $PKG_LIBS"
+  PKG_CFLAGS="-I$BREWDIR/include -DARROW_R_WITH_S3"
+else
+  PKG_CFLAGS="-I$BREWDIR/include -DARROW_R_WITH_PARQUET -DARROW_R_WITH_DATASET -DARROW_R_WITH_S3"
 fi
-PKG_CFLAGS="-I$BREWDIR/include -DARROW_R_WITH_S3"
 
 # Cleanup
 echo "rm -Rf .deps" >> cleanup

--- a/apache-arrow
+++ b/apache-arrow
@@ -33,10 +33,8 @@ PKG_LIBS="-lparquet -larrow_dataset -larrow -larrow_bundled_dependencies -lthrif
 PKG_DIRS="-L$BREWDIR/lib"
 if [ "$VERSION" = "3.0.0" ] || [ "$VERSION" = "2.0.0" ]; then
   PKG_LIBS="$PKG_DIRS $PKG_LIBS"
-  PKG_CFLAGS="-I$BREWDIR/include -DARROW_R_WITH_S3"
-else
-  PKG_CFLAGS="-I$BREWDIR/include -DARROW_R_WITH_PARQUET -DARROW_R_WITH_DATASET -DARROW_R_WITH_S3"
 fi
+PKG_CFLAGS="-I$BREWDIR/include -DARROW_R_WITH_PARQUET -DARROW_R_WITH_DATASET -DARROW_R_WITH_S3"
 
 # Cleanup
 echo "rm -Rf .deps" >> cleanup


### PR DESCRIPTION
For Arrow 4.0.0, we added two new cflags to Makevars  to control whether the Dataset and Parquet features are enabled, defaulting both to off (in https://github.com/apache/arrow/pull/9610). I neglected to add those in https://github.com/autobrew/scripts/pull/9. This adds them. Thank you!