### PR TITLE
Add GCS flag to apache-arrow

### DIFF
--- a/apache-arrow
+++ b/apache-arrow
@@ -44,7 +44,7 @@ BROTLI_LIBS="-lbrotlienc-static -lbrotlidec-static -lbrotlicommon-static"
 fi
 
 PKG_LIBS="-L$BREWDIR/lib -lparquet -larrow_dataset -larrow -larrow_bundled_dependencies -lthrift -llz4 -lsnappy -lzstd $AWS_LIBS $BROTLI_LIBS -lpthread -lcurl"
-PKG_CFLAGS="-I$BREWDIR/include -DARROW_R_WITH_PARQUET -DARROW_R_WITH_DATASET -DARROW_R_WITH_JSON -DARROW_R_WITH_S3"
+PKG_CFLAGS="-I$BREWDIR/include -DARROW_R_WITH_PARQUET -DARROW_R_WITH_DATASET -DARROW_R_WITH_JSON -DARROW_R_WITH_S3 -DARROW_R_WITH_GCS"
 
 # Prevent linking against other libs in /usr/local/lib
 for FILE in $BREWDIR/lib/*.a; do


### PR DESCRIPTION
It's on in the autobrew binaries but the R package isn't aware unless this flag is turned on here.